### PR TITLE
Add path prefix to Gatsby config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,4 +3,5 @@ module.exports = {
     title: "react-live-build-error",
   },
   plugins: [],
+  pathPrefix: '/my-app',
 };

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "develop": "gatsby develop",
     "start": "gatsby develop",
-    "build": "gatsby build",
-    "serve": "gatsby serve",
+    "build": "gatsby build --prefix-paths",
+    "serve": "gatsby serve --prefix-paths",
     "clean": "gatsby clean",
     "server": "node index.js"
   },


### PR DESCRIPTION
This fixes the issue described at https://github.com/FormidableLabs/react-live/issues/261, by telling Gatsby where to load  static assets from.

Gatsby docs: https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/